### PR TITLE
updatedWikiUserAssociation

### DIFF
--- a/app/controllers/wikis_controller.rb
+++ b/app/controllers/wikis_controller.rb
@@ -13,7 +13,7 @@ class WikisController < ApplicationController
   end
 
   def create
-    @wiki = Wiki.create(wiki_params)
+    @wiki = current_user.wikis.new(wiki_params)
 
     if @wiki.save
       redirect_to @wiki, notice: "Wiki was saved successfully."

--- a/app/views/wikis/show.html.erb
+++ b/app/views/wikis/show.html.erb
@@ -2,7 +2,7 @@
 <h1>
   <%= @wiki.title %> <br>
   <small>
-    submitted <%= time_ago_in_words(@wiki.created_at) %> ago by <%= @user %>
+    submitted <%= time_ago_in_words(@wiki.created_at) %> ago by <%= @wiki.user %>
   </small>
 </h1>
 


### PR DESCRIPTION
Made updates to the user association with wiki posts.  

Still having issues in displaying the username.  

examples come out as follows : 

`submitted 6 minutes ago by #<User:0x007f3a82eea958>`, instead of the users name. 